### PR TITLE
Extract class matcher to test Helper class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/.phpunit.cache
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "autoload": {
         "psr-4": {
             "Robbinploeger\\OopTesting\\": "src/"
-        }
+        },
+        "classmap": ["tests/ClassFixturesHelper.php"]
     },
     "authors": [
         {
@@ -12,6 +13,8 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "symfony/yaml": "^6.0",
+        "symfony/var-dumper": "^6.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0d81ed5b9b3b3e82553fe450cba4e5d",
+    "content-hash": "8c9287cb9ffee41d50f5365e776bc163",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -1997,6 +1997,251 @@
             "time": "2021-10-20T20:35:02+00:00"
         },
         {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.25.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-30T18:21:41+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v6.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "38358405ae948963c50a3aae3dfea598223ba15e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/38358405ae948963c50a3aae3dfea598223ba15e",
+                "reference": "38358405ae948963c50a3aae3dfea598223ba15e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v6.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-02T12:58:14+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "e77f3ea0b21141d771d4a5655faa54f692b34af5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e77f3ea0b21141d771d4a5655faa54f692b34af5",
+                "reference": "e77f3ea0b21141d771d4a5655faa54f692b34af5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-26T17:23:29+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.1",
             "source": {
@@ -2113,5 +2358,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,11 +4,11 @@
          bootstrap="vendor/autoload.php"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
-         forceCoversAnnotation="false"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          convertDeprecationsToExceptions="true"
+         colors="true"
          failOnRisky="true"
          failOnWarning="true"
          verbose="true">

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -2,9 +2,19 @@
 
 namespace Robbinploeger\OopTesting;
 
-class Logger {
-    public function log(string $message): void
+class Logger
+{
+    public const INFO = 'INFO';
+
+    public bool $enabled;
+
+    public function info(string $message): void
     {
-        echo $message;
+        $this->log(self::INFO, $message);
+    }
+
+    public function log(string $level, string $message): void
+    {
+        echo "$level: $message";
     }
 }

--- a/tests/ClassFixturesHelper.php
+++ b/tests/ClassFixturesHelper.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+use function PHPUnit\Framework\assertArrayHasKey;
+use function PHPUnit\Framework\assertEquals;
+
+/**
+ * This class contains helpers for testing expected class structure.
+ */
+class ClassFixturesHelper
+{
+    private array $fixtures = [];
+
+    public function __construct()
+    {
+        foreach (glob(__DIR__ . '/fixtures/*.yaml') as $file) {
+            $this->fixtures += Yaml::parse(file_get_contents($file));
+        }
+    }
+
+    /**
+     * Voor elke method in de fixture wordt het volgende bevestigd:
+     * - De class bevat alle gespecificeerde properties met het juiste type
+     * - De class bevat een method met de juiste naam
+     * - Elke parameter in de fixture bestaat op de method
+     * - Elke method parameter heeft het juiste type
+     */
+    public function assertMatches(string $path, string $class): void
+    {
+        $shortName = (new ReflectionClass($class))->getShortName();
+        $fixture = $this->fixtures[$shortName];
+        $reflection = $this->reflect($path, $class);
+
+        foreach ($fixture['properties'] as $name => $type) {
+            assertArrayHasKey($name, $reflection['properties'], "De class moet de property `$name` bevatten.");
+            assertEquals($type, $reflection['properties'][$name], "De class property `$name` moet van het type `$type` zijn.");
+        }
+
+        foreach ($fixture['methods'] as $method => $params) {
+            assertArrayHasKey($method, $reflection['methods'], "De class moet de method `$method` bevatten.");
+
+            $reflectedMethod = $reflection['methods'][$method];
+            foreach ($params as $name => $type) {
+                assertArrayHasKey($name, $reflectedMethod, "De methode `$method` moet de parameter `$name` bevatten.");
+                assertEquals($type, $reflectedMethod[$name], "De parameter `$name` op de methode `$method` moet van het type `$type` zijn.");
+            }
+        }
+    }
+
+    /**
+     * Reflect class and parse it into the same structure as the yaml.
+     */
+    private function reflect(string $path, string $class)
+    {
+        require_once $path;
+        $reflection = new ReflectionClass($class);
+
+        $properties = $methods = [];
+        foreach ($reflection->getProperties() as $property) {
+            $properties[$property->name] = $property->getType()->getName();
+        }
+        foreach ($reflection->getMethods() as $method) {
+            $params = [];
+            foreach ($method->getParameters() as $param) {
+                $params[$param->name] = $param->getType()->getName();
+            }
+            $methods[$method->name] = $params;
+        }
+
+        return compact('properties', 'methods');
+    }
+}

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -5,78 +5,18 @@ use Robbinploeger\OopTesting\Logger;
 
 class LoggerTest extends TestCase
 {
+    private ClassFixturesHelper $helper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->helper = new ClassFixturesHelper();
+    }
+
     /** @test */
     public function test_class_matches_fixture()
     {
-        // Include uitwerking van student
-        include(__DIR__ . '/../src/Logger.php');
-        // Class gebruikt voor dit voorbeeld:
-        //
-        //class Logger {
-        //    public function log(string $message): void
-        //    {
-        //        echo $message;
-        //    }
-        //}
-
-
-        // Definitie van vereisten van de class
-        $fixture = [
-            'methods' => [
-                'log' => [
-                    'parameters' => [
-                        'message' => [
-                            'type' => 'string',
-                        ],
-                    ],
-                ],
-            ],
-            'properties' => [],
-        ];
-
-        $reflectionClass = new ReflectionClass(Logger::class);
-
-        /**
-         * Voor elke method in de fixture wordt het volgende bevestigd:
-         * - De class bevat een method met de juiste naam
-         * - De method in de class heeft evenveel parameters als de fixture
-         * - Elke parameter in de fixture bestaat op de method
-         * - Elek parameter heeft het juiste type
-         */
-        foreach ($fixture['methods'] as $methodName => $methodFixture) {
-            $this->assertTrue($reflectionClass->hasMethod($methodName), "De class moet de methode `$methodName` bevatten");
-            $reflectionMethod = $reflectionClass->getMethod($methodName);
-            $reflectionParameters = $reflectionMethod->getParameters();
-
-            $expectedParameterCount = count($methodFixture['parameters']);
-            $this->assertCount($expectedParameterCount, $reflectionParameters, "De methode `$methodName` moet $expectedParameterCount parameters bevatten.");
-
-            foreach ($methodFixture['parameters'] as $parameterName => $parameterFixture) {
-                // Vind de juiste ReflectionParameter. Dit zou een stuk makkelijker zijn als de lijst van parameters een associative array was...
-                $reflectionParameter = array_reduce(
-                    $reflectionParameters,
-                    function ($result, $currentParameter) use ($parameterName) {
-                        if ($result instanceof ReflectionParameter) {
-                            return $currentParameter;
-                        }
-
-                        if ($currentParameter->getName() === $parameterName) {
-                            return $currentParameter;
-                        }
-
-                        return null;
-                    });
-
-                $this->assertNotNull($reflectionParameter, "De methode `$methodName` moet de parameter `$parameterName` bevatten");
-
-                // De juiste parameter bestaat. Check nu dat het juiste type ook bestaat.
-                $expectedParameterType = $parameterFixture['type'];
-                $this->assertEquals(
-                    $expectedParameterType,
-                    $reflectionParameter->getType()?->getName(),
-                    "De parameter `$parameterName` op de methode `$methodName` moet van het type `$expectedParameterType` zijn."
-                );
-            }
-        }
+        $this->helper->assertMatches(__DIR__ . '/../src/Logger.php', Logger::class);
     }
 }

--- a/tests/fixtures/logger.yaml
+++ b/tests/fixtures/logger.yaml
@@ -1,0 +1,9 @@
+Logger:
+  properties:
+    enabled: bool
+  methods:
+    info:
+      message: string
+    log:
+      level: string
+      message: string


### PR DESCRIPTION
Supergoed idee om de classes zo te testen. 

Ik vond de syntax om de class structuur te beschrijven niet zo handig. Het leek me fijner om de fixtures gewoon in een simpel yaml file te kunnen definieren.
Met een standaard Helper class kun je dan snel class structuur tests toevoegen.

De `symfony/var-dumper` is eigenlijk niet nodig. Die had ik gebruikt voor debugging :)

Ik heb nog geen private methods en properties getest. Daar moet waarschijnlijk nog een regeltje in de reflection worden toegevoegd om ze leesbaar te maken.